### PR TITLE
feat: add Sentry to start getting error logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-radio-group": "^1.3.7",
         "@radix-ui/react-scroll-area": "^1.2.9",
         "@radix-ui/react-slot": "^1.2.3",
+        "@sentry/react": "^9.34.0",
         "@tailwindcss/vite": "^4.1.10",
         "@tanstack/react-query": "^5.81.2",
         "@types/react-router-dom": "^5.3.3",
@@ -2232,6 +2233,98 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "9.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.34.0.tgz",
+      "integrity": "sha512-pXVznvP4CROejYtk6y7UQvPTieWz2vXjukGlO45fsnQa9nNo30lkQh3Ws2HZw2YbTxYZQYx75FBDezwKl2q0hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "9.34.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "9.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.34.0.tgz",
+      "integrity": "sha512-HT/EBRl1DR8XqlJk2wFNPJFcnIzNcEDjmW7C/o7K0GeP5jcSH0dKpcH7ykz2bi46gMRPrkO5EK2eXGK81KYI3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "9.34.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "9.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.34.0.tgz",
+      "integrity": "sha512-joYSqWltmpkcqI8Gg8jwFtPv0F01whmuQfNGoGaL7Z6B/xO1vvkqEudrg1tmswUHhqtYpZYaEaCvrmv0sPGCfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "9.34.0",
+        "@sentry/core": "9.34.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "9.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.34.0.tgz",
+      "integrity": "sha512-GCtqMFk9WwrU3JNz1tlCFAhzmNfgZhLRaS0cLzoTuxPbG3CC2VUIWYEOw7+AdCJZGm8ElTMxu+BkChgGb8qthQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "9.34.0",
+        "@sentry/core": "9.34.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "9.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-9.34.0.tgz",
+      "integrity": "sha512-6oJxU7JEA/RCgMTVlHXT54U9d0DWg61GgzyLTM+FUa8OUrAoK/t+CZGSMc/13nYN8xs7vcpiORdRx0ogch9zGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "9.34.0",
+        "@sentry-internal/feedback": "9.34.0",
+        "@sentry-internal/replay": "9.34.0",
+        "@sentry-internal/replay-canvas": "9.34.0",
+        "@sentry/core": "9.34.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "9.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.34.0.tgz",
+      "integrity": "sha512-M/zikVaE3KLkhCFDyrHB35sF7pVkB2RPy07BcRsdFsSsdpjoG+Zq2Sxth2tMTbjd0x9Vtb/X6LVjyCj9GSEvVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "9.34.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-9.34.0.tgz",
+      "integrity": "sha512-xrai0g8qBS0AyiAytHlrBiTPu1zG7DNNh4GodAkHcd1j2iVti2c+AR7KgUY7UrsrjXd8Fpy7c+qo+5DnHLpulw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "9.34.0",
+        "@sentry/core": "9.34.0",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
     },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
@@ -5158,6 +5251,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -6979,7 +7081,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-radio-group": "^1.3.7",
     "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-slot": "^1.2.3",
+    "@sentry/react": "^9.34.0",
     "@tailwindcss/vite": "^4.1.10",
     "@tanstack/react-query": "^5.81.2",
     "@types/react-router-dom": "^5.3.3",

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -1,0 +1,10 @@
+import * as Sentry from "@sentry/react";
+
+// Only initialize Sentry in production
+if (process.env.NODE_ENV === 'production') {
+  Sentry.init({
+      dsn: "https://0eb2022ec9ba425594bf8d0fd3147e0f@sentry.hive.fi/28",
+      sendDefaultPii: true,
+      integrations: [],
+    });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,10 +15,25 @@ import App from '@/App';
 import ErrorBoundary from '@/components/ErrorBoundary';
 
 import '@/index.css';
+import './instrument';
+import * as Sentry from '@sentry/react';
+
 
 const queryClient = new QueryClient();
 
-createRoot(document.getElementById('root')!).render(
+const container = document.getElementById('root')!;
+const root = createRoot(container, {
+    // Callback called when an error is thrown and not caught by an ErrorBoundary.
+  onUncaughtError: Sentry.reactErrorHandler((error, errorInfo) => {
+    console.warn('Uncaught error', error, errorInfo.componentStack);
+  }),
+  // Callback called when React catches an error in an ErrorBoundary.
+  onCaughtError: Sentry.reactErrorHandler(),
+  // Callback called when React automatically recovers from errors.
+  onRecoverableError: Sentry.reactErrorHandler(),
+});
+
+root.render(
   <StrictMode>
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
Let's start to use Sentry so we can start to track error logs happening in production. 

If you are not familiar with Sentry, I am more than happy to introduce you later how that works.