### PR TITLE
fix: fix the bug in overlapping check.

### DIFF
--- a/src/lib/bookingFormUtils.ts
+++ b/src/lib/bookingFormUtils.ts
@@ -118,7 +118,8 @@ const calculateSlots = (
 const overlappingCheck = (start: string, end: string, endSlots: Slot[]): boolean => {
   let inRange: boolean = false;
   for (const slot of endSlots) {
-    if (isEqual(new Date(start), slot.slot)) inRange = true;
+    if (isEqual(new Date(start), addMinutes(slot.slot, -TIME_SLOT_INTERVAL))) inRange = true;
+
     if (inRange) {
       if (!slot.avail) return false;
       if (isEqual(new Date(end), slot.slot)) return true;


### PR DESCRIPTION
Previously, if `3:00–3:15` was booked, then any booking starting from `3:15` would fail the check.

This happened because the logic incorrectly compared the `startTime` with the slot time at `endTime`, which should have been excluded.