### PR TITLE
daniel-optimized-booking-info

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -10,6 +10,7 @@ import BasicGrids from '@/components/BasicGrids';
 import BookingsLayer from '@/components/BookingsLayer';
 import CalendarHeader from '@/components/CalendarHeader';
 import OperationRow from '@/components/OperationRow';
+import RoomMap from '@/components/RoomMap';
 import { CELL_HEIGHT_PX, CELL_WIDTH_PX } from '@/config';
 import { styleGenerator } from '@/lib/tools';
 
@@ -21,6 +22,8 @@ const Main = () => (
     <div data-role='main' className='mx-4 mt-5 mb-12 h-fit w-fit'>
       {/* Operation row */}
       <OperationRow />
+
+      <RoomMap />
 
       {/* Calendar */}
       <div data-role='calendar'>

--- a/src/components/RoomMap.tsx
+++ b/src/components/RoomMap.tsx
@@ -1,0 +1,23 @@
+import { ROOM_MAP } from '@/config';
+import { cn } from '@/lib/utils';
+
+const RoomMap = () => (
+  <div data-role='room-map' className='mb-4 flex w-fit items-center justify-start gap-4 text-sm'>
+    <div data-role='room-map-label' className='font-semibold'>
+      Meeting rooms:{' '}
+    </div>
+    <div data-role='room-map-list' className='flex w-fit gap-2 text-sm'>
+      {ROOM_MAP.map((room) => (
+        <div
+          data-role='room-map-room'
+          key={room.id}
+          className='flex items-center justify-start gap-2'
+        >
+          <div className={cn('rounded-md px-3 py-0.5 border', room.color)}>{room.name}</div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export default RoomMap;

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,8 +8,8 @@
 import { ThrowInternalError } from './lib/errorHandler';
 
 const ROOM_MAP: { id: number; name: string; color: string }[] = [
-  { id: 1, name: 'big', color: 'bg-blue-600/20 border-blue-500/40' },
-  { id: 2, name: 'small', color: 'bg-cyan-600/20 border-cyan-500/40' },
+  { id: 1, name: 'Big', color: 'bg-blue-600/20 border-blue-500/40' },
+  { id: 2, name: 'Small', color: 'bg-cyan-600/20 border-cyan-500/40' },
 ];
 
 /**


### PR DESCRIPTION
1 Display `bookedBy` instead of room name(now we have room map)
2 When height > 16px, we leave some space as usual.
3 When 12 px < height < 16 px, we remove the space to avoid the overflow.
4 When height < 12px, text is hidden (the `title` can be seen on hover,  as a fallback).