### PR TITLE
fix: reduce size of the footer for mobile

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,8 +2,8 @@ import { Heart } from 'lucide-react';
 
 const Footer = () => {
   return (
-    <footer className='bg-accent flex h-14 items-center justify-center border-t'>
-      <div className='text-muted-foreground text-center text-sm flex items-center gap-2'>
+    <footer className='bg-accent flex h-10 md:h-12 items-center justify-center border-t'>
+      <div className='text-muted-foreground text-center text-xs md:text-sm flex items-center gap-2'>
         <span>Developed with</span>
         <Heart className='h-4 w-4 fill-sky-400 stroke-0 animate-pulse' /> 
         <span>by{' '}


### PR DESCRIPTION
Let's reduce the footer size for mobile.

<img width="603" height="198" alt="image" src="https://github.com/user-attachments/assets/f9c295b8-221b-4957-ac80-bd754b6188ea" />
