### PR TITLE
fix: to remove an incorrect error msg on slow device.

### DIFF
--- a/src/components/TanQuery.tsx
+++ b/src/components/TanQuery.tsx
@@ -1,11 +1,13 @@
 import { memo, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
 import { useAtomValue, useSetAtom } from 'jotai';
 import isEqual from 'lodash/isEqual';
 
 import { CACHE_DURATION } from '@/config';
 import { getSlots } from '@/lib/apiFetcher';
 import { bookingsAtom, startAtom } from '@/lib/atoms';
+import { RedirectingMsg } from '@/lib/axiosFetcher';
 import { ThrowInvalidIncomingDataErr } from '@/lib/errorHandler';
 import { type WeekBookings, weekBookingsGenerator } from '@/lib/weekBookings';
 
@@ -40,10 +42,10 @@ const TanQuery = memo(() => {
   }, [bookings, setBookingsAtom]);
 
   useEffect(() => {
-    if (isError) {
-      console.error('Query error:', error);
-      ThrowInvalidIncomingDataErr('Data fetching error.');
-    }
+    if (!isError) return;
+    // If error is a redirecting to auth page, ignore it.
+    if (axios.isCancel(error) && error.message === RedirectingMsg) return;
+    ThrowInvalidIncomingDataErr('Data fetching error.');
   }, [isError, error]);
 
   return <></>;

--- a/src/lib/axiosFetcher.ts
+++ b/src/lib/axiosFetcher.ts
@@ -10,6 +10,8 @@ import axios from 'axios';
 import { API_URL, ENDPOINT_AUTH, FETCHER_TIMEOUT } from '@/config';
 import { getUser, setUser } from '@/lib/userStore';
 
+const RedirectingMsg = 'No token, redirecting.';
+
 const axiosFetcher = axios.create({
   baseURL: API_URL,
   timeout: FETCHER_TIMEOUT,
@@ -21,7 +23,7 @@ axiosFetcher.interceptors.request.use((config) => {
   const token = getUser()?.token;
   if (!token) {
     window.location.replace(`${API_URL}/${ENDPOINT_AUTH}`);
-    return Promise.reject(new axios.Cancel('No token, redirecting.'));
+    return Promise.reject(new axios.Cancel(RedirectingMsg));
   }
   config.headers.Authorization = `Bearer ${token}`;
   return config;
@@ -43,4 +45,4 @@ axiosFetcher.interceptors.response.use(
   },
 );
 
-export { axiosFetcher };
+export { axiosFetcher, RedirectingMsg };


### PR DESCRIPTION
**The bug**
- Axios redirects to auth page when `token` is null, then returns a `Promise.cancel`.
- TanQuery catches and throws the `Promise.cancel` as an error.
- Normally, when page is redirected, components are unmounted, so users can not see the error msg from `redirect`.
- But on slow device, there may be a delay between `Promise.cancel` and `Page redirect`, then users can see the error msg from TanQuery.

**Fix**
Ignore the `redirect` error on TanQuery.

**Reproduce**
DevTools: Network Throttling-3G

**Testing**
No tests now, we don't have a mock api for auth, so we need to push online and see. But it would not break other logic I think.