### PR TITLE
feat(Loading): improve loading spinner

### DIFF
--- a/mock/test.ts
+++ b/mock/test.ts
@@ -97,7 +97,7 @@ const mocks: MockMethod[] = [
   {
     url: '/reservation',
     method: 'get',
-    timeout: 400,
+    timeout: 2000,
     response: ({ query }) => {
       const { start } = query;
       return generateMockedData(start);

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,14 +1,18 @@
-/**
- * @file Loading.tsx
- * @summary A spinning.
- *
- * @author Xin (Daniel) Feng
- * @contact intra: @xifeng
- */
+import type { CSSProperties } from 'react';
 
-const Loading = () => (
-  <div className='flex h-screen w-screen items-center justify-center'>
-    <div className='h-10 w-10 animate-spin rounded-full border-4 border-gray-300 border-t-transparent' />
+const Loading = ({ style }: { style?: CSSProperties }) => (
+  <div
+    className='bg-background/60 flex h-full w-full items-center justify-center opacity-70 dark:opacity-80'
+    style={style}
+  >
+    <div
+      className='h-10 w-10 animate-spin rounded-full bg-gradient-to-r from-purple-800 to-blue-600/80'
+      style={{
+        WebkitMask:
+          'radial-gradient(farthest-side, transparent calc(100% - 4px), #000 calc(100% - 4px))',
+        WebkitMaskComposite: 'destination-in',
+      }}
+    />
   </div>
 );
 

--- a/src/components/calendarView/BookingCanvas.tsx
+++ b/src/components/calendarView/BookingCanvas.tsx
@@ -22,9 +22,7 @@ const BookingCanvas = ({
 }) => {
   const start = useAtomValue(startAtom);
   const rooms = useAtomValue(roomsAtom);
-  const [loaderSize, setLoaderSize] = useState<{ width: number; height: number } | undefined>(
-    undefined,
-  );
+  const [loaderSize, setLoaderSize] = useState<CSSProperties | undefined>(undefined);
 
   const bookings: WeekBookings = useAtomValue(bookingsAtom);
   const isPending =
@@ -53,7 +51,7 @@ const BookingCanvas = ({
   return (
     <div className='absolute top-0 left-0 z-10 h-full w-full'>
       {isPending ? (
-        <Loading style={loaderSize ? (loaderSize as CSSProperties) : undefined} />
+        <Loading style={loaderSize} />
       ) : (
         <>
           <FreeLayer containerRef={containerRef} start={start} rooms={rooms} />

--- a/src/components/calendarView/BookingCanvas.tsx
+++ b/src/components/calendarView/BookingCanvas.tsx
@@ -1,3 +1,4 @@
+import { type CSSProperties, useEffect, useState } from 'react';
 import { useIsFetching } from '@tanstack/react-query';
 import { useAtomValue } from 'jotai';
 
@@ -6,7 +7,6 @@ import FreeLayer from '@/components/calendarView/FreeLayer';
 import Loading from '@/components/Loading';
 import { bookingsAtom, roomsAtom, startAtom } from '@/lib/atoms';
 import type { WeekBookings } from '@/lib/weekBookings';
-
 /**
  * @description
  * A stacked canvas layer for bookings.
@@ -22,6 +22,9 @@ const BookingCanvas = ({
 }) => {
   const start = useAtomValue(startAtom);
   const rooms = useAtomValue(roomsAtom);
+  const [loaderSize, setLoaderSize] = useState<{ width: number; height: number } | undefined>(
+    undefined,
+  );
 
   const bookings: WeekBookings = useAtomValue(bookingsAtom);
   const isPending =
@@ -30,10 +33,27 @@ const BookingCanvas = ({
       predicate: (query) => query.state.status === 'pending',
     }) > 0;
 
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const visibleWidth = Math.max(
+      0,
+      Math.min(rect.right, window.innerWidth) - Math.max(rect.left, 0),
+    );
+    const visibleHeight = Math.max(
+      0,
+      Math.min(rect.bottom, window.innerHeight) -
+        Math.max(rect.top, 0) -
+        Math.max(document.querySelector('footer')?.getBoundingClientRect().height || 0, 0),
+    );
+
+    setLoaderSize({ width: visibleWidth, height: visibleHeight });
+  }, [containerRef]);
+
   return (
     <div className='absolute top-0 left-0 z-10 h-full w-full'>
       {isPending ? (
-        <Loading />
+        <Loading style={loaderSize ? (loaderSize as CSSProperties) : undefined} />
       ) : (
         <>
           <FreeLayer containerRef={containerRef} start={start} rooms={rooms} />

--- a/src/components/calendarView/CalendarView.tsx
+++ b/src/components/calendarView/CalendarView.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useRef } from 'react';
+import { useIsFetching } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
 
 import BasicGrids from '@/components/calendarView/BasicGrids';
 import BookingCanvas from '@/components/calendarView/BookingCanvas';
 import CalendarDateRow from '@/components/calendarView/CalendarDateRow';
 import CalendarTimeColumn from '@/components/calendarView/CalendarTimeColumn';
 import { CELL_HEIGHT_PX, CELL_WIDTH_PX, OPEN_HOURS_IDX } from '@/config';
+import { startAtom } from '@/lib/atoms';
 import { slotsInAHour, styleGenerator } from '@/lib/tools';
+import { cn } from '@/lib/utils';
 
 const rows = (OPEN_HOURS_IDX[1] - OPEN_HOURS_IDX[0]) / slotsInAHour;
 
@@ -14,6 +18,7 @@ const CalendarView = () => {
   const dateRowRef = useRef<HTMLDivElement>(null);
   const timeColumnRef = useRef<HTMLDivElement>(null);
   const dataContainerRef = useRef<HTMLDivElement>(null);
+  const start = useAtomValue(startAtom);
 
   useEffect(() => {
     const syncScroll = () => {
@@ -36,6 +41,12 @@ const CalendarView = () => {
       dataContainer?.removeEventListener('scroll', syncScroll);
     };
   }, []);
+
+  const isPending =
+    useIsFetching({
+      queryKey: ['slots', start],
+      predicate: (query) => query.state.status === 'pending',
+    }) > 0;
 
   return (
     <div data-role='calendar' className='flex flex-1 overflow-hidden'>
@@ -65,7 +76,7 @@ const CalendarView = () => {
         {/* Data */}
         <div
           data-role='calendar-data-scroll-container'
-          className='scrollbar-hide flex-1 overflow-auto'
+          className={cn('scrollbar-hide flex-1', !isPending && 'overflow-auto')}
           ref={dataContainerRef}
         >
           <div


### PR DESCRIPTION
- Fix positioning so it stays centered
- Change spinner color to a gradient
- Add semi-transparent background for visual feedback
- Disable page scrolling while loading

I thought if we can make it fully cover the calendar for stronger feedback.
This approach may work well during auth.  But, since the loader also appears during date changes, too strong feedback may not be so suitable.

So I used a bit complex way for a better balance.