### PR TITLE
feat: improve loading to avoid taking more than screen size

### DIFF
--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -61,7 +61,7 @@ const AuthGuard = ({ children }: AuthGuardProps) => {
 
   if (isCheckingAuth) {
     return (
-      <div className='flex h-[100dvh] w-full flex-col items-center justify-center bg-background'>
+      <div className='flex h-screen flex-col items-center justify-center bg-background'>
         <div className='flex flex-col items-center space-y-4'>
           <Loading />
           <p className='text-muted-foreground animate-pulse'>Checking authentication...</p>

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -61,7 +61,7 @@ const AuthGuard = ({ children }: AuthGuardProps) => {
 
   if (isCheckingAuth) {
     return (
-      <div className='flex h-screen flex-col items-center justify-center bg-background'>
+      <div className='flex h-screen w-full flex-col items-center justify-center bg-background'>
         <div className='flex flex-col items-center space-y-4'>
           <Loading />
           <p className='text-muted-foreground animate-pulse'>Checking authentication...</p>

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,14 +1,8 @@
-/**
- * @file Loading.tsx
- * @summary A spinning.
- *
- * @author Xin (Daniel) Feng
- * @contact intra: @xifeng
- */
+import { cn } from "@/lib/utils";
 
-const Loading = () => (
-  <div className='flex h-screen w-screen items-center justify-center'>
-    <div className='h-10 w-10 animate-spin rounded-full border-4 border-gray-300 border-t-transparent' />
+const Loading = ({ className }: { className?: string }) => (
+  <div className='flex items-center justify-center'>
+    <div className={cn('h-10 w-10 animate-spin rounded-full border-4 border-gray-300 border-t-transparent', className)} />
   </div>
 );
 

--- a/src/components/layout/HeaderMenu.tsx
+++ b/src/components/layout/HeaderMenu.tsx
@@ -37,7 +37,7 @@ const HeaderMenu = () => {
   const [open, setOpen] = useState(false);
 
   // To prevent there is not a start.
-  if (!start) return <Loading />;
+  if (!start) return <Loading className='h-4 w-4' />;
 
   const startDate = newDate(start);
 


### PR DESCRIPTION
This pull request introduces improvements to the loading indicator component and its usage across the application, focusing on better customization and consistency. The main changes include refactoring the `Loading` component to accept custom styling, updating its usage in other components to leverage this flexibility, and minor adjustments to layout for improved UI consistency.

**Component refactor and usage updates:**

* Refactored the `Loading` component in `Loading.tsx` to accept an optional `className` prop, allowing for more flexible sizing and styling. Removed unused comments and streamlined the layout.
* Updated `HeaderMenu.tsx` to pass a custom size (`h-4 w-4`) to the `Loading` component, ensuring the loading spinner matches the intended design in that context.

**UI consistency improvements:**

* Changed the height property in the loading state of `AuthGuard.tsx` from `h-[100dvh]` to `h-screen` for more consistent full-page loading layouts.