### PR TITLE
feat: do not show room maps if there is less than 2 rooms to display

### DIFF
--- a/src/components/RoomMap.tsx
+++ b/src/components/RoomMap.tsx
@@ -15,6 +15,8 @@ const RoomMap = () => {
     });
   };
 
+  if (rooms.length < 2) return null;
+
   return (
     <div data-role='room-map' className='mb-4 flex w-fit items-center justify-start gap-4 text-sm shrink-0'>
       <div data-role='room-map-label' className='flex items-center gap-1 font-semibold'>


### PR DESCRIPTION
This pull request introduces a small update to the `RoomMap` component to improve its rendering logic. Now, the component will not render anything if there are fewer than two rooms, helping to prevent unnecessary UI elements from appearing.

* Prevents the `RoomMap` component from rendering when the `rooms` array contains fewer than two items.