### PR TITLE
fix: update AuthGuard button layout to use grid for better responsiveness

### DIFF
--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -67,20 +67,20 @@ const AuthGuard = ({ children }: AuthGuardProps) => {
           </div>
         </div>
         <div
-          className={`flex flex-col items-center gap-6 transition-all duration-300 lg:flex-row ${
+          className={`grid grid-cols-1 items-center gap-6 transition-all duration-300 lg:grid-cols-2 ${
             showButtons
               ? 'translate-y-0 opacity-100'
               : 'pointer-events-none translate-y-3 opacity-0'
           }`}
         >
           <Button
-            className='w-full lg:w-1/2'
+            className='w-full'
             onClick={() => window.location.assign(`${API_URL}/${endpoint_auth('42')}`)}
           >
             Login with 42
           </Button>
           <Button
-            className='w-full lg:w-1/2'
+            className='w-full'
             onClick={() => window.location.assign(`${API_URL}/${endpoint_auth('keycloak')}`)}
           >
             Login with Hive ID


### PR DESCRIPTION
The layout of buttons is switched to `grid`, to remove the overflow. 
- The width of buttons fits the width of 2 buttons.
- The width of buttons should be same (So the actual width of each btn == the width of the largest item)

<img width="2112" height="910" alt="image" src="https://github.com/user-attachments/assets/f88b419f-4934-44b1-9cfd-cb6fae467e3c" />
<img width="724" height="668" alt="image" src="https://github.com/user-attachments/assets/856daf3a-0aea-493d-b504-7eff92e1dd44" />
